### PR TITLE
WIP: Add support for multiple browsers, logging skipped, and grouping by test suite

### DIFF
--- a/index.js
+++ b/index.js
@@ -7,11 +7,15 @@ class GitLabJUnitReporter {
     this.out = out || process.stdout;
     this.silent = silent;
 
-    this.results = [];
+    this.results = {};
   }
 
   report(launcher, data) {
-    this.results.push({ launcher, data });
+    if (!this.results[launcher]) {
+      this.results[launcher] = [];
+    }
+
+    this.results[launcher].push({ data });
   }
 
   finish() {
@@ -23,25 +27,64 @@ class GitLabJUnitReporter {
   }
 
   _formatOutput() {
-    let root = builder.create('testsuite');
+    let root = builder.create('testsuites');
 
-    root.attribute('tests', this.results.filter(it => !it.data.skipped).length);
-    root.attribute('failures', this.results.filter(it => it.data.failed).length);
+    var totals = Object.keys(this.results).reduce((previous, browser) => {
+      let suite = root.element('testsuite');
+      suite.attribute('name', browser);
+      var result = this.results[browser];
 
-    for (let { data } of this.results) {
-      if (data.skipped) {
-        continue;
+      suite.attribute('tests', result.length);
+      suite.attribute('failures', result.filter(it => it.data.failed).length);
+      suite.attribute('skipped', result.filter(it => it.data.skipped).length);
+
+      for (let { data } of result) {
+        let el = suite.element('testcase');
+
+        let name = data.name;
+        let className = name;
+
+        const firstColon = name.indexOf(':');
+
+        if (firstColon !== -1) {
+          className = className.substring(0, firstColon);
+          name = name.substring(firstColon + 2);
+        }
+
+        el.attribute('name', name);
+        el.attribute('classname', `[${browser}] ${className}`);
+
+        if (data.skipped) {
+          let skipped = el.element('skipped');
+          continue;
+        }
+
+        el.attribute('time', durationFromMs(data.runDuration));
+
+        if (data.logs && data.logs.length) {
+          let output = el.element('system-out');
+          output.text(JSON.stringify(data.logs, null, '\t'));
+        }
+
+        if (data.error) {
+          let failure = el.element('failure');
+          failure.text(data.error.message);
+
+          let stderr = el.element('system-err');
+          stderr.text(JSON.stringify(data.error, null, '\t'));
+        }
       }
 
-      let el = root.element('testcase');
-      el.attribute('name', data.name);
-      el.attribute('time', durationFromMs(data.runDuration));
-
-      if (data.error) {
-        let failure = el.element('failure');
-        failure.text(data.error.message);
-      }
-    }
+      return {
+        failures: previous.failures + result.filter(it => it.data.failed).length,
+        skipped: previous.skipped + result.filter(it => it.data.skipped).length,
+        tests: previous.tests + result.length,
+      };
+    }, {
+      tests: 0,
+      failures: 0,
+      skipped: 0
+    });
 
     return root.end({ pretty: true });
   }


### PR DESCRIPTION
This adds a few features

## Support for multiple browsers
If you run a `testem` test with multiple launchers, this library currently creates a valid file, but GitLab has a limitation where it can only handle one testcase for each `classname` and `name` combination. So currently, GitLab only displays the result for one of the launchers. This patch does two things to address this. First, test results are broken up into separate test suites based on launcher. Next, we populate the launcher name in the `classname` attribute, so that the same test in two separate launchers are no longer seen as duplicates.

## Skipped tests are included in results
This patch starts allowing for the recording of skipped tests, while marking them as skipped and keeping track of the count for parent elements. This allows for proper counts of tests, skips, failures  and successes.

## console methods are recorded
Right now GitLab doesn't support displaying it, but this patch now records all console method calls into the `system-out` element

## module identification
For some testers like `QUnit`, `testem` prepends the module name to the test name, separating with a colon (`:`) This will separate the values by the colon, moving the module name to the `classname` attribute
